### PR TITLE
feat: microinverters support

### DIFF
--- a/custom_components/solar_plus_intelbras/api.py
+++ b/custom_components/solar_plus_intelbras/api.py
@@ -78,14 +78,33 @@ class SolarPlusIntelbrasApiClient:
     async def async_get_data(self) -> Any:
         """Get data from the API."""
         await self.async_ensure_token()
-        return await self._api_wrapper(
+        headers = {
+            "Authorization": f"Bearer {self._access_token}",
+            "plus": self._plus,
+        }
+        inverters_task = self._api_wrapper(
             method="get",
             url=f"{SOLAR_PLUS_INTELBRAS_API_URL}/plants/{self._plant_id}/inverters?limit=20&page=1",
-            headers={
-                "Authorization": f"Bearer {self._access_token}",
-                "plus": self._plus,
-            },
+            headers=headers,
         )
+        microinverters_task = self._api_wrapper(
+            method="get",
+            url=f"{SOLAR_PLUS_INTELBRAS_API_URL}/plants/{self._plant_id}/microinverters?limit=20&page=1",
+            headers=headers,
+        )
+        inverters_response, microinverters_response = await asyncio.gather(
+            inverters_task, microinverters_task
+        )
+
+        # Merge rows from both responses
+        inverters_rows = inverters_response.get("rows", []) if inverters_response else []
+        microinverters_rows = microinverters_response.get("rows", []) if microinverters_response else []
+
+        merged = inverters_response or {}
+        merged["rows"] = inverters_rows + microinverters_rows
+        merged["count"] = len(merged["rows"])
+
+        return merged
 
     async def async_get_notifications(self, start_date: None | date = None, end_date: None | date = None) -> dict:
         """Get notifications from the API."""


### PR DESCRIPTION
[async_get_data](cci:1://file:///Users/murilobast/Projects/Brainstorm/HA-solar-plus-intelbras/custom_components/solar_plus_intelbras/api.py:77:4-106:21) was only hitting `/inverters`, which returns nothing for plants with microinverters. Now it fetches both `/inverters` and `/microinverters` in parallel and merges the rows. Both endpoints return the same structure so no other changes needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated data fetching to concurrently retrieve information from both inverter and microinverter endpoints for improved performance.
  * Device data is now consolidated into a unified response, providing a complete view of your solar system configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->