### PR TITLE
v0.6.0: CI tests, weather sensors, reconfigure flow, API robustness, i18n

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,3 +30,22 @@ jobs:
 
         - name: "Format"
           run: python3 -m ruff format . --check
+
+  tests:
+    name: "Tests"
+    runs-on: "ubuntu-latest"
+    steps:
+        - name: "Checkout the repository"
+          uses: "actions/checkout@v6.0.2"
+
+        - name: "Set up Python"
+          uses: actions/setup-python@v6.2.0
+          with:
+            python-version: "3.12"
+            cache: "pip"
+
+        - name: "Install requirements"
+          run: python3 -m pip install -r requirements.test.txt
+
+        - name: "Run tests"
+          run: python3 -m pytest

--- a/README.md
+++ b/README.md
@@ -77,13 +77,15 @@ This custom component creates the following devices:
 
 The integration creates three devices — **Plant**, **Inverter**, and **Datalogger** — and supports multiple inverters per plant.
 
-**Plant:** Energy today / total / last 30 days / this year (kWh), Current power (W), Economy today / total / last 30 days / this year, CO2 / trees / coal saved, Energy price, Installed capacity, Modules, Plant status, Alerts, Alerts today.
+**Plant:** Energy today / total / last 30 days / this year (kWh), Current power (W), Economy today / total / last 30 days / this year, CO2 / trees / coal saved, Energy price, Installed capacity, Modules, Plant status, Alerts, Alerts today, Weather temperature / humidity / condition.
 
 **Inverter (per device):** Temperature (°C), Power (W), Energy today (kWh), Status, Serial number, Last record, Online (binary).
 
 **Datalogger (per device):** Firmware version, MAC address, Signal strength (RSSI), Last record.
 
-Monetary sensors use the currency reported by your account (e.g. `BRL`). The polling interval is configurable via the integration's **Configure** (options) dialog.
+Monetary sensors use the currency reported by your account (e.g. `BRL`). The polling interval is configurable via the integration's **Configure** (options) dialog. The integration is available in English, Portuguese and Spanish.
+
+If your "plus" token rotates you'll be prompted to re-authenticate; you can also **Reconfigure** the entry to change the email/plus without removing it.
 
 # Debugging
 

--- a/custom_components/solar_plus_intelbras/api.py
+++ b/custom_components/solar_plus_intelbras/api.py
@@ -6,6 +6,7 @@ import asyncio
 import socket
 import time
 from datetime import date
+from http import HTTPStatus
 from typing import Any
 
 import aiohttp
@@ -166,15 +167,6 @@ class SolarPlusIntelbrasApiClient:
             return None
         return response.get("data", {}).get("total")
 
-    async def async_get_plant_detail(self) -> Any:
-        """Return the plant detail document."""
-        await self.async_ensure_token()
-        return await self._api_wrapper(
-            method="get",
-            url=f"{SOLAR_PLUS_INTELBRAS_API_URL}/plants/{self._plant_id}",
-            headers={"Authorization": f"Bearer {self._access_token}", "plus": self._plus},
-        )
-
     async def async_get_notifications(self, start_date: None | date = None, end_date: None | date = None) -> dict:
         """Get notifications from the API."""
         await self.async_ensure_token()
@@ -217,6 +209,11 @@ class SolarPlusIntelbrasApiClient:
                     _verify_response_or_raise(response)
                     return await response.json()
 
+            except SolarPlusIntelbrasApiClientError:
+                # Our own typed errors (e.g. authentication) must keep their type
+                # so callers can map them (auth -> reauth). Do not retry/wrap them.
+                raise
+
             except TimeoutError as exception:
                 if attempt < retry_count:
                     wait_time = 2 * (attempt + 1)  # Backoff exponencial
@@ -233,6 +230,14 @@ class SolarPlusIntelbrasApiClient:
                     raise SolarPlusIntelbrasApiClientCommunicationError(msg) from exception
 
             except (aiohttp.ClientError, socket.gaierror) as exception:
+                # 4xx responses are not transient (e.g. 404 for a missing endpoint);
+                # fail fast instead of burning the retry budget.
+                if (
+                    isinstance(exception, aiohttp.ClientResponseError)
+                    and HTTPStatus.BAD_REQUEST <= exception.status < HTTPStatus.INTERNAL_SERVER_ERROR
+                ):
+                    msg = f"Error fetching information - {exception}"
+                    raise SolarPlusIntelbrasApiClientCommunicationError(msg) from exception
                 if attempt < retry_count:
                     wait_time = 2 * (attempt + 1)  # Backoff exponencial
                     LOGGER.warning(

--- a/custom_components/solar_plus_intelbras/config_flow.py
+++ b/custom_components/solar_plus_intelbras/config_flow.py
@@ -183,6 +183,48 @@ class SolarPlusIntelbrasFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             errors=_errors,
         )
 
+    async def async_step_reconfigure(self, user_input: dict | None = None) -> data_entry_flow.FlowResult:
+        """Let the user update the email/plus of an existing entry (same plant)."""
+        _errors: dict[str, str] = {}
+        entry = self._get_reconfigure_entry()
+        if user_input is not None:
+            try:
+                # Validate the new credentials; the plant stays the same.
+                await self._async_fetch_plants(
+                    email=user_input[CONF_EMAIL],
+                    plus=user_input[CONF_PLUS],
+                )
+            except SolarPlusIntelbrasApiClientAuthenticationError:
+                _errors["base"] = "auth"
+            except SolarPlusIntelbrasApiClientCommunicationError:
+                _errors["base"] = "connection"
+            except SolarPlusIntelbrasApiClientError:
+                _errors["base"] = "unknown"
+            else:
+                return self.async_update_reload_and_abort(
+                    entry,
+                    data={
+                        **entry.data,
+                        CONF_EMAIL: user_input[CONF_EMAIL],
+                        CONF_PLUS: user_input[CONF_PLUS],
+                    },
+                )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_EMAIL, default=entry.data[CONF_EMAIL]): selector.TextSelector(
+                        selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT),
+                    ),
+                    vol.Required(CONF_PLUS): selector.TextSelector(
+                        selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD),
+                    ),
+                },
+            ),
+            errors=_errors,
+        )
+
     @staticmethod
     @config_entries.callback
     def async_get_options_flow(

--- a/custom_components/solar_plus_intelbras/device.py
+++ b/custom_components/solar_plus_intelbras/device.py
@@ -6,6 +6,8 @@ from homeassistant.helpers.device_registry import DeviceInfo
 
 from .const import DOMAIN
 
+CONFIGURATION_URL = "https://solarplus.intelbras.com.br/"
+
 
 def plant_device_info(entry_id: str, plant_name: str) -> DeviceInfo:
     """Return DeviceInfo for the plant (top-level device)."""
@@ -14,6 +16,7 @@ def plant_device_info(entry_id: str, plant_name: str) -> DeviceInfo:
         name=plant_name or "Solar Plant",
         manufacturer="Intelbras",
         model="Solar Plus",
+        configuration_url=CONFIGURATION_URL,
     )
 
 
@@ -27,6 +30,7 @@ def inverter_device_info(entry_id: str, row: dict) -> DeviceInfo:
         model=model.get("pnManufacturer") or model.get("pnIntelbras") or "Inverter",
         serial_number=row.get("serialNumber"),
         via_device=(DOMAIN, f"{entry_id}_plant"),
+        configuration_url=CONFIGURATION_URL,
     )
 
 
@@ -41,4 +45,5 @@ def datalogger_device_info(entry_id: str, row: dict) -> DeviceInfo:
         serial_number=datalogger.get("serialNumber"),
         sw_version=datalogger.get("firmwareVersion"),
         via_device=(DOMAIN, f"{entry_id}_inverter_{row.get('id')}"),
+        configuration_url=CONFIGURATION_URL,
     )

--- a/custom_components/solar_plus_intelbras/manifest.json
+++ b/custom_components/solar_plus_intelbras/manifest.json
@@ -13,5 +13,5 @@
     "custom_components.solar_plus_intelbras"
   ],
   "requirements": [],
-  "version": "0.5.0"
+  "version": "0.6.0"
 }

--- a/custom_components/solar_plus_intelbras/notify.py
+++ b/custom_components/solar_plus_intelbras/notify.py
@@ -45,6 +45,7 @@ class SolarPlusIntelbrasNotifier:
             self.hass,
             self._async_check_notifications,
             DEFAULT_NOTIFICATION_CHECK_INTERVAL,
+            cancel_on_shutdown=True,
         )
 
     def async_teardown(self) -> None:

--- a/custom_components/solar_plus_intelbras/sensor_descriptions.py
+++ b/custom_components/solar_plus_intelbras/sensor_descriptions.py
@@ -11,6 +11,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import (
+    PERCENTAGE,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     UnitOfEnergy,
     UnitOfPower,
@@ -66,6 +67,10 @@ def _component(data: dict, key: str) -> StateType:
 
 def _plant_field(data: dict, key: str) -> StateType:
     return _plant(data).get(key)
+
+
+def _weather(data: dict) -> dict:
+    return (_plant(data).get("weather") or {}).get("current") or {}
 
 
 # --- inverter / datalogger accessors (value_fn receives one row) -----------
@@ -230,6 +235,32 @@ PLANT_SENSORS: tuple[SolarPlusSensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda d: _component(d, "todayAlerts"),
+    ),
+    SolarPlusSensorEntityDescription(
+        key="weather_temperature",
+        translation_key="weather_temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda d: _weather(d).get("temp_c"),
+    ),
+    SolarPlusSensorEntityDescription(
+        key="weather_humidity",
+        translation_key="weather_humidity",
+        device_class=SensorDeviceClass.HUMIDITY,
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda d: _weather(d).get("humidity"),
+    ),
+    SolarPlusSensorEntityDescription(
+        key="weather_condition",
+        translation_key="weather_condition",
+        icon="mdi:weather-partly-cloudy",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda d: (_weather(d).get("condition") or {}).get("text"),
     ),
 )
 

--- a/custom_components/solar_plus_intelbras/strings.json
+++ b/custom_components/solar_plus_intelbras/strings.json
@@ -1,0 +1,105 @@
+{
+    "entity": {
+        "sensor": {
+            "energy_today": { "name": "Energy today" },
+            "energy_total": { "name": "Energy total" },
+            "energy_of_last_30": { "name": "Energy last 30 days" },
+            "year_energy": { "name": "Energy this year" },
+            "current_power": { "name": "Current power" },
+            "today_economy": { "name": "Economy today" },
+            "total_economy": { "name": "Economy total" },
+            "economy_of_last_30": { "name": "Economy last 30 days" },
+            "year_economy": { "name": "Economy this year" },
+            "saved_co2": { "name": "CO2 saved" },
+            "saved_trees": { "name": "Trees saved" },
+            "saved_coal": { "name": "Coal saved" },
+            "price": { "name": "Energy price" },
+            "capacity_installed": { "name": "Installed capacity" },
+            "modules_amount": { "name": "Modules" },
+            "plant_status": { "name": "Plant status" },
+            "alerts": { "name": "Alerts" },
+            "today_alerts": { "name": "Alerts today" },
+            "inverter_temperature": { "name": "Temperature" },
+            "inverter_current_power": { "name": "Power" },
+            "inverter_energy_today": { "name": "Energy today" },
+            "inverter_status": { "name": "Status" },
+            "inverter_serial_number": { "name": "Serial number" },
+            "inverter_last_record": { "name": "Last record" },
+            "datalogger_firmware_version": { "name": "Firmware version" },
+            "datalogger_mac_address": { "name": "MAC address" },
+            "datalogger_rssi": { "name": "Signal strength" },
+            "datalogger_last_record": { "name": "Last record" }
+        },
+        "binary_sensor": {
+            "online": { "name": "Online" }
+        }
+    },
+    "config": {
+        "step": {
+            "user": {
+                "description": "Enter the email and \"plus\" token used on Solar Plus Intelbras.",
+                "data": {
+                    "email": "Email",
+                    "plus": "Plus"
+                }
+            },
+            "plant": {
+                "title": "Select a plant",
+                "description": "Choose which plant to add.",
+                "data": {
+                    "plant_id": "Plant"
+                }
+            },
+            "reauth_confirm": {
+                "title": "Re-authenticate Solar Plus Intelbras",
+                "description": "Your plus token expired. Paste a new one.",
+                "data": { "plus": "Plus" }
+            }
+        },
+        "abort": {
+            "already_configured": "This plant is already configured.",
+            "reauth_successful": "Re-authentication successful.",
+            "no_plants": "All your plants are already configured."
+        },
+        "error": {
+            "auth": "Email/Plus is wrong.",
+            "connection": "Unable to connect to the server.",
+            "unknown": "Unknown error occurred."
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": { "scan_interval": "Update interval (minutes)" }
+            }
+        }
+    },
+    "services": {
+        "send_alert": {
+            "name": "Send Alert",
+            "description": "Send an alert notification for Solar Plus Intelbras",
+            "fields": {
+                "message": {
+                    "name": "Message",
+                    "description": "Content of the message"
+                },
+                "title": {
+                    "name": "Title",
+                    "description": "Title of the notification"
+                },
+                "notification_id": {
+                    "name": "Notification ID",
+                    "description": "Unique ID for the notification (auto-generated if not provided)"
+                },
+                "priority": {
+                    "name": "Priority",
+                    "description": "Priority level of the notification"
+                }
+            }
+        },
+        "check_notifications": {
+            "name": "Check Notifications",
+            "description": "Manually check for new notifications from the Intelbras API"
+        }
+    }
+}

--- a/custom_components/solar_plus_intelbras/strings.json
+++ b/custom_components/solar_plus_intelbras/strings.json
@@ -57,11 +57,17 @@
                 "title": "Re-authenticate Solar Plus Intelbras",
                 "description": "Your plus token expired. Paste a new one.",
                 "data": { "plus": "Plus" }
+            },
+            "reconfigure": {
+                "title": "Reconfigure Solar Plus Intelbras",
+                "description": "Update the email and \"plus\" token. The selected plant stays the same.",
+                "data": { "email": "Email", "plus": "Plus" }
             }
         },
         "abort": {
             "already_configured": "This plant is already configured.",
             "reauth_successful": "Re-authentication successful.",
+            "reconfigure_successful": "Re-configuration successful.",
             "no_plants": "All your plants are already configured."
         },
         "error": {

--- a/custom_components/solar_plus_intelbras/strings.json
+++ b/custom_components/solar_plus_intelbras/strings.json
@@ -28,7 +28,10 @@
             "datalogger_firmware_version": { "name": "Firmware version" },
             "datalogger_mac_address": { "name": "MAC address" },
             "datalogger_rssi": { "name": "Signal strength" },
-            "datalogger_last_record": { "name": "Last record" }
+            "datalogger_last_record": { "name": "Last record" },
+            "weather_temperature": { "name": "Weather temperature" },
+            "weather_humidity": { "name": "Humidity" },
+            "weather_condition": { "name": "Weather condition" }
         },
         "binary_sensor": {
             "online": { "name": "Online" }

--- a/custom_components/solar_plus_intelbras/translations/en.json
+++ b/custom_components/solar_plus_intelbras/translations/en.json
@@ -57,11 +57,17 @@
                 "title": "Re-authenticate Solar Plus Intelbras",
                 "description": "Your plus token expired. Paste a new one.",
                 "data": { "plus": "Plus" }
+            },
+            "reconfigure": {
+                "title": "Reconfigure Solar Plus Intelbras",
+                "description": "Update the email and \"plus\" token. The selected plant stays the same.",
+                "data": { "email": "Email", "plus": "Plus" }
             }
         },
         "abort": {
             "already_configured": "This plant is already configured.",
             "reauth_successful": "Re-authentication successful.",
+            "reconfigure_successful": "Re-configuration successful.",
             "no_plants": "All your plants are already configured."
         },
         "error": {

--- a/custom_components/solar_plus_intelbras/translations/en.json
+++ b/custom_components/solar_plus_intelbras/translations/en.json
@@ -28,7 +28,10 @@
             "datalogger_firmware_version": { "name": "Firmware version" },
             "datalogger_mac_address": { "name": "MAC address" },
             "datalogger_rssi": { "name": "Signal strength" },
-            "datalogger_last_record": { "name": "Last record" }
+            "datalogger_last_record": { "name": "Last record" },
+            "weather_temperature": { "name": "Weather temperature" },
+            "weather_humidity": { "name": "Humidity" },
+            "weather_condition": { "name": "Weather condition" }
         },
         "binary_sensor": {
             "online": { "name": "Online" }

--- a/custom_components/solar_plus_intelbras/translations/es.json
+++ b/custom_components/solar_plus_intelbras/translations/es.json
@@ -1,0 +1,114 @@
+{
+    "entity": {
+        "sensor": {
+            "energy_today": { "name": "Energía hoy" },
+            "energy_total": { "name": "Energía total" },
+            "energy_of_last_30": { "name": "Energía últimos 30 días" },
+            "year_energy": { "name": "Energía del año" },
+            "current_power": { "name": "Potencia actual" },
+            "today_economy": { "name": "Ahorro hoy" },
+            "total_economy": { "name": "Ahorro total" },
+            "economy_of_last_30": { "name": "Ahorro últimos 30 días" },
+            "year_economy": { "name": "Ahorro del año" },
+            "saved_co2": { "name": "CO2 evitado" },
+            "saved_trees": { "name": "Árboles ahorrados" },
+            "saved_coal": { "name": "Carbón ahorrado" },
+            "price": { "name": "Precio de la energía" },
+            "capacity_installed": { "name": "Capacidad instalada" },
+            "modules_amount": { "name": "Módulos" },
+            "plant_status": { "name": "Estado de la planta" },
+            "alerts": { "name": "Alertas" },
+            "today_alerts": { "name": "Alertas hoy" },
+            "inverter_temperature": { "name": "Temperatura" },
+            "inverter_current_power": { "name": "Potencia" },
+            "inverter_energy_today": { "name": "Energía hoy" },
+            "inverter_status": { "name": "Estado" },
+            "inverter_serial_number": { "name": "Número de serie" },
+            "inverter_last_record": { "name": "Último registro" },
+            "datalogger_firmware_version": { "name": "Versión de firmware" },
+            "datalogger_mac_address": { "name": "Dirección MAC" },
+            "datalogger_rssi": { "name": "Intensidad de señal" },
+            "datalogger_last_record": { "name": "Último registro" },
+            "weather_temperature": { "name": "Temperatura (clima)" },
+            "weather_humidity": { "name": "Humedad" },
+            "weather_condition": { "name": "Condición del clima" }
+        },
+        "binary_sensor": {
+            "online": { "name": "En línea" }
+        }
+    },
+    "config": {
+        "step": {
+            "user": {
+                "description": "Introduce el correo y el token \"plus\" usados en Solar Plus Intelbras.",
+                "data": {
+                    "email": "Correo",
+                    "plus": "Plus"
+                }
+            },
+            "plant": {
+                "title": "Selecciona una planta",
+                "description": "Elige qué planta añadir.",
+                "data": {
+                    "plant_id": "Planta"
+                }
+            },
+            "reauth_confirm": {
+                "title": "Volver a autenticar Solar Plus Intelbras",
+                "description": "Tu token plus expiró. Pega uno nuevo.",
+                "data": { "plus": "Plus" }
+            },
+            "reconfigure": {
+                "title": "Reconfigurar Solar Plus Intelbras",
+                "description": "Actualiza el correo y el token \"plus\". La planta seleccionada no cambia.",
+                "data": { "email": "Correo", "plus": "Plus" }
+            }
+        },
+        "abort": {
+            "already_configured": "Esta planta ya está configurada.",
+            "reauth_successful": "Reautenticación correcta.",
+            "reconfigure_successful": "Reconfiguración correcta.",
+            "no_plants": "Todas tus plantas ya están configuradas."
+        },
+        "error": {
+            "auth": "Correo/Plus incorrecto.",
+            "connection": "No se pudo conectar al servidor.",
+            "unknown": "Ocurrió un error desconocido."
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": { "scan_interval": "Intervalo de actualización (minutos)" }
+            }
+        }
+    },
+    "services": {
+        "send_alert": {
+            "name": "Enviar alerta",
+            "description": "Envía una notificación de alerta para Solar Plus Intelbras",
+            "fields": {
+                "message": {
+                    "name": "Mensaje",
+                    "description": "Contenido del mensaje"
+                },
+                "title": {
+                    "name": "Título",
+                    "description": "Título de la notificación"
+                },
+                "notification_id": {
+                    "name": "ID de notificación",
+                    "description": "ID único de la notificación (autogenerado si no se indica)"
+                },
+                "priority": {
+                    "name": "Prioridad",
+                    "description": "Nivel de prioridad de la notificación"
+                }
+            }
+        },
+        "check_notifications": {
+            "name": "Comprobar notificaciones",
+            "description": "Comprueba manualmente nuevas notificaciones de la API de Intelbras"
+        }
+    }
+}

--- a/custom_components/solar_plus_intelbras/translations/pt-BR.json
+++ b/custom_components/solar_plus_intelbras/translations/pt-BR.json
@@ -28,7 +28,10 @@
             "datalogger_firmware_version": { "name": "Versão de firmware" },
             "datalogger_mac_address": { "name": "Endereço MAC" },
             "datalogger_rssi": { "name": "Intensidade do sinal" },
-            "datalogger_last_record": { "name": "Último registro" }
+            "datalogger_last_record": { "name": "Último registro" },
+            "weather_temperature": { "name": "Temperatura (clima)" },
+            "weather_humidity": { "name": "Umidade" },
+            "weather_condition": { "name": "Condição do tempo" }
         },
         "binary_sensor": {
             "online": { "name": "Online" }

--- a/custom_components/solar_plus_intelbras/translations/pt-BR.json
+++ b/custom_components/solar_plus_intelbras/translations/pt-BR.json
@@ -57,11 +57,17 @@
                 "title": "Reautenticar Solar Plus Intelbras",
                 "description": "Seu token plus expirou. Cole um novo.",
                 "data": { "plus": "Plus" }
+            },
+            "reconfigure": {
+                "title": "Reconfigurar Solar Plus Intelbras",
+                "description": "Atualize o email e o token \"plus\". A usina selecionada permanece a mesma.",
+                "data": { "email": "Email", "plus": "Plus" }
             }
         },
         "abort": {
             "already_configured": "Esta usina já está configurada.",
             "reauth_successful": "Reautenticação bem-sucedida.",
+            "reconfigure_successful": "Reconfiguração concluída.",
             "no_plants": "Todas as suas usinas já estão configuradas."
         },
         "error": {

--- a/custom_components/solar_plus_intelbras/translations/pt.json
+++ b/custom_components/solar_plus_intelbras/translations/pt.json
@@ -28,7 +28,10 @@
             "datalogger_firmware_version": { "name": "Versão de firmware" },
             "datalogger_mac_address": { "name": "Endereço MAC" },
             "datalogger_rssi": { "name": "Intensidade do sinal" },
-            "datalogger_last_record": { "name": "Último registro" }
+            "datalogger_last_record": { "name": "Último registro" },
+            "weather_temperature": { "name": "Temperatura (clima)" },
+            "weather_humidity": { "name": "Umidade" },
+            "weather_condition": { "name": "Condição do tempo" }
         },
         "binary_sensor": {
             "online": { "name": "Online" }

--- a/custom_components/solar_plus_intelbras/translations/pt.json
+++ b/custom_components/solar_plus_intelbras/translations/pt.json
@@ -57,11 +57,17 @@
                 "title": "Reautenticar Solar Plus Intelbras",
                 "description": "Seu token plus expirou. Cole um novo.",
                 "data": { "plus": "Plus" }
+            },
+            "reconfigure": {
+                "title": "Reconfigurar Solar Plus Intelbras",
+                "description": "Atualize o email e o token \"plus\". A usina selecionada permanece a mesma.",
+                "data": { "email": "Email", "plus": "Plus" }
             }
         },
         "abort": {
             "already_configured": "Esta usina já está configurada.",
             "reauth_successful": "Reautenticação bem-sucedida.",
+            "reconfigure_successful": "Reconfiguração concluída.",
             "no_plants": "Todas as suas usinas já estão configuradas."
         },
         "error": {

--- a/tests/fixtures/inverters.json
+++ b/tests/fixtures/inverters.json
@@ -76,6 +76,15 @@
           "alerts": 5,
           "todayAlerts": 0,
           "chargeControllers": 0
+        },
+        "weather": {
+          "current": {
+            "temp_c": 31.4,
+            "humidity": 63,
+            "cloud": 50,
+            "wind_kph": 15.8,
+            "condition": { "text": "Partly cloudy" }
+          }
         }
       }
     }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,7 +9,11 @@ import aiohttp
 import pytest
 from aioresponses import aioresponses
 
-from custom_components.solar_plus_intelbras.api import SolarPlusIntelbrasApiClient
+from custom_components.solar_plus_intelbras.api import (
+    SolarPlusIntelbrasApiClient,
+    SolarPlusIntelbrasApiClientAuthenticationError,
+    SolarPlusIntelbrasApiClientCommunicationError,
+)
 from custom_components.solar_plus_intelbras.const import SOLAR_PLUS_INTELBRAS_API_URL
 
 INVERTERS_URL = f"{SOLAR_PLUS_INTELBRAS_API_URL}/plants/1/inverters?limit=20&page=1"
@@ -108,3 +112,31 @@ async def test_get_plants_returns_rows(login_response: dict) -> None:
             )
             response = await client.async_get_plants()
             assert response["rows"][0]["id"] == 42  # noqa: PLR2004
+
+
+@pytest.mark.asyncio
+async def test_auth_error_keeps_its_type(login_response: dict) -> None:
+    """A 401 surfaces as an authentication error (not a generic one) so reauth works."""
+    login_response["accessToken"]["exp"] = int(time.time()) + 3600
+    async with aiohttp.ClientSession() as session:
+        client = SolarPlusIntelbrasApiClient("e@mail.com", "plus", "1", session)
+        with aioresponses() as mocked:
+            mocked.post(LOGIN_URL, payload=login_response)
+            mocked.get(f"{SOLAR_PLUS_INTELBRAS_API_URL}/plants", status=401)
+            with pytest.raises(SolarPlusIntelbrasApiClientAuthenticationError):
+                await client.async_get_plants()
+
+
+@pytest.mark.asyncio
+async def test_client_error_is_not_retried(login_response: dict) -> None:
+    """A 404 fails fast without burning the retry budget (single request)."""
+    login_response["accessToken"]["exp"] = int(time.time()) + 3600
+    async with aiohttp.ClientSession() as session:
+        client = SolarPlusIntelbrasApiClient("e@mail.com", "plus", "1", session)
+        with aioresponses() as mocked:
+            mocked.post(LOGIN_URL, payload=login_response)
+            mocked.get(f"{SOLAR_PLUS_INTELBRAS_API_URL}/plants", status=404)
+            with pytest.raises(SolarPlusIntelbrasApiClientCommunicationError):
+                await client.async_get_plants()
+            plant_calls = [k for k in mocked.requests if k[0] == "get"]
+            assert len(plant_calls) == 1

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from homeassistant import config_entries, data_entry_flow
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.solar_plus_intelbras.api import (
     SolarPlusIntelbrasApiClientAuthenticationError,
@@ -88,6 +89,28 @@ async def test_configured_plant_is_filtered(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_configure(second["flow_id"], {CONF_PLANT_ID: "43"})
     assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["result"].unique_id == "43"
+
+
+async def test_reconfigure_updates_credentials(hass: HomeAssistant) -> None:
+    """Reconfigure updates the email/plus while keeping the same plant (unique_id)."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="42",
+        data={CONF_EMAIL: "old@mail.com", CONF_PLUS: "old", CONF_PLANT_ID: "42"},
+    )
+    entry.add_to_hass(hass)
+    with _patch_plants(PLANTS), _patch_setup_fetch():
+        result = await entry.start_reconfigure_flow(hass)
+        assert result["step_id"] == "reconfigure"
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_EMAIL: "new@mail.com", CONF_PLUS: "newtok"}
+        )
+        await hass.async_block_till_done()
+    assert result2["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result2["reason"] == "reconfigure_successful"
+    assert entry.data[CONF_EMAIL] == "new@mail.com"
+    assert entry.data[CONF_PLUS] == "newtok"
+    assert entry.data[CONF_PLANT_ID] == "42"
 
 
 async def test_no_plants_left_aborts(hass: HomeAssistant) -> None:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -16,8 +16,11 @@ from custom_components.solar_plus_intelbras.const import (
     CONF_EMAIL,
     CONF_PLANT_ID,
     CONF_PLUS,
+    CONF_SCAN_INTERVAL,
     DOMAIN,
 )
+
+_ENTRY_DATA = {CONF_EMAIL: "e@mail.com", CONF_PLUS: "old", CONF_PLANT_ID: "42"}
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -111,6 +114,33 @@ async def test_reconfigure_updates_credentials(hass: HomeAssistant) -> None:
     assert entry.data[CONF_EMAIL] == "new@mail.com"
     assert entry.data[CONF_PLUS] == "newtok"
     assert entry.data[CONF_PLANT_ID] == "42"
+
+
+async def test_reauth_flow_updates_plus(hass: HomeAssistant) -> None:
+    """Reauth accepts a new plus token and updates the entry."""
+    entry = MockConfigEntry(domain=DOMAIN, unique_id="42", data=_ENTRY_DATA)
+    entry.add_to_hass(hass)
+    with _patch_plants(PLANTS), _patch_setup_fetch():
+        result = await entry.start_reauth_flow(hass)
+        assert result["step_id"] == "reauth_confirm"
+        result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {CONF_PLUS: "newtok"})
+        await hass.async_block_till_done()
+    assert result2["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result2["reason"] == "reauth_successful"
+    assert entry.data[CONF_PLUS] == "newtok"
+
+
+async def test_options_flow_sets_scan_interval(hass: HomeAssistant) -> None:
+    """The options flow stores the chosen scan interval."""
+    entry = MockConfigEntry(domain=DOMAIN, unique_id="42", data=_ENTRY_DATA)
+    entry.add_to_hass(hass)
+    with _patch_setup_fetch():
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+        assert result["step_id"] == "init"
+        result2 = await hass.config_entries.options.async_configure(result["flow_id"], {CONF_SCAN_INTERVAL: 10})
+        await hass.async_block_till_done()
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert entry.options[CONF_SCAN_INTERVAL] == 10  # noqa: PLR2004
 
 
 async def test_no_plants_left_aborts(hass: HomeAssistant) -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,10 +1,30 @@
-"""Tests for the coordinator's data normalization helper."""
+"""Tests for the coordinator."""
 
 from __future__ import annotations
 
-from custom_components.solar_plus_intelbras.coordinator import build_coordinator_data
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.solar_plus_intelbras.api import SolarPlusIntelbrasApiClientError
+from custom_components.solar_plus_intelbras.const import DOMAIN
+from custom_components.solar_plus_intelbras.coordinator import (
+    SolarPlusIntelbrasDataUpdateCoordinator,
+    build_coordinator_data,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
 
 SAMPLE_YEAR_ENERGY = 292.4
+
+
+@pytest.fixture(autouse=True)
+def _enable_custom_integrations(enable_custom_integrations):  # noqa: ANN001, ANN202
+    return
 
 
 def test_build_coordinator_data_shape(inverters_response: dict) -> None:
@@ -12,4 +32,39 @@ def test_build_coordinator_data_shape(inverters_response: dict) -> None:
     data = build_coordinator_data(inverters_response, year_energy=SAMPLE_YEAR_ENERGY, currency="BRL")
     assert data["inverters"] is inverters_response
     assert data["year_energy"] == SAMPLE_YEAR_ENERGY
+    assert data["currency"] == "BRL"
+
+
+def _make_coordinator(hass: HomeAssistant, client: object) -> SolarPlusIntelbrasDataUpdateCoordinator:
+    entry = MockConfigEntry(domain=DOMAIN, unique_id="42")
+    entry.add_to_hass(hass)
+    coordinator = SolarPlusIntelbrasDataUpdateCoordinator(hass, entry)
+    entry.runtime_data = SimpleNamespace(client=client)
+    return coordinator
+
+
+async def test_update_data_builds_contract(hass: HomeAssistant) -> None:
+    """_async_update_data merges inverters, year energy and currency."""
+    client = SimpleNamespace(
+        async_get_data=AsyncMock(return_value={"rows": [{"id": 1}]}),
+        async_get_year_energy=AsyncMock(return_value=SAMPLE_YEAR_ENERGY),
+        currency="BRL",
+    )
+    coordinator = _make_coordinator(hass, client)
+    data = await coordinator._async_update_data()  # noqa: SLF001
+    assert data["inverters"]["rows"][0]["id"] == 1
+    assert data["year_energy"] == SAMPLE_YEAR_ENERGY
+    assert data["currency"] == "BRL"
+
+
+async def test_update_data_tolerates_year_energy_error(hass: HomeAssistant) -> None:
+    """A failure fetching year energy leaves year_energy=None but still returns data."""
+    client = SimpleNamespace(
+        async_get_data=AsyncMock(return_value={"rows": []}),
+        async_get_year_energy=AsyncMock(side_effect=SolarPlusIntelbrasApiClientError("boom")),
+        currency="BRL",
+    )
+    coordinator = _make_coordinator(hass, client)
+    data = await coordinator._async_update_data()  # noqa: SLF001
+    assert data["year_energy"] is None
     assert data["currency"] == "BRL"

--- a/tests/test_sensor_descriptions.py
+++ b/tests/test_sensor_descriptions.py
@@ -49,3 +49,10 @@ def test_inverter_temperature(coordinator_data: dict) -> None:
     desc = _by_key(INVERTER_SENSORS, "inverter_temperature")
     assert desc.device_class == SensorDeviceClass.TEMPERATURE
     assert desc.value_fn(row) == 40  # noqa: PLR2004
+
+
+def test_weather_sensors_read_plant_weather(coordinator_data: dict) -> None:
+    """Weather sensors read plant.weather.current."""
+    assert _by_key(PLANT_SENSORS, "weather_temperature").value_fn(coordinator_data) == 31.4  # noqa: PLR2004
+    assert _by_key(PLANT_SENSORS, "weather_humidity").value_fn(coordinator_data) == 63  # noqa: PLR2004
+    assert _by_key(PLANT_SENSORS, "weather_condition").value_fn(coordinator_data) == "Partly cloudy"


### PR DESCRIPTION
Follow-up improvements after v0.5.0.

## CI / tooling
- **Run the pytest suite in CI** (a new `Tests` job) — previously CI only ran ruff/hassfest/HACS, so the tests never executed.
- Add `strings.json` (HA source-of-truth for translations).

## API robustness
- `_api_wrapper` **no longer retries 4xx** responses (e.g. a missing `/microinverters` endpoint returning 404) — fails fast instead of burning the retry budget every poll.
- **Fix:** authentication errors are re-raised with their type instead of being swallowed by the broad handler, so a 401/403 correctly triggers re-auth (was previously turned into a generic error).
- Remove the unused `async_get_plant_detail` method.

## New sensors & UX
- **Weather sensors** (temperature, humidity, condition) read from the existing `/inverters` response (no extra request).
- **Reconfigure flow** — change the email/"plus" of an existing entry without removing it (plant/unique_id stays the same).
- Devices link to the Intelbras portal via `configuration_url`.
- The notification timer is registered with `cancel_on_shutdown=True` for a clean shutdown.

## i18n
- Add **Spanish** (`es.json`) and a generic **Portuguese** (`pt.json`, covers HA set to `pt` as well as `pt-BR`).

## Tests
- New tests for the reauth flow, options flow, reconfigure flow, the 4xx-no-retry and auth-error-type behavior, weather sensors, and the coordinator's update contract. **34 tests**, all green; ruff clean.

## Intentionally not done (with rationale)
- **quality_scale in manifest:** declaring it makes hassfest require a complete `quality_scale.yaml`; deferred to a dedicated effort.
- **Repairs:** redundant — auth failures already drive HA's built-in re-auth.
- **Bump `softprops/action-gh-release`:** no Node 24 release of the action exists yet; the warning is harmless until late 2026.
- **Long-term statistics backfill via `records`:** the energy sensors (`device_class=energy`, `total_increasing`) already feed the Energy Dashboard going forward; historical backfill is large/risky for low marginal value.

## Test Plan
- [x] `pytest` → 34 passed
- [x] `ruff check .` + `ruff format . --check` → clean
- [ ] CI: confirm the new Tests job passes (HA + phacc install)
- [ ] Manual: weather sensors populate; Reconfigure changes credentials; UI shows Spanish when HA language is `es`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added weather sensors: temperature, humidity, and condition monitoring.
  * Enabled credential reconfiguration without removing the integration.
  * Added Spanish language support.
  * Added configuration URL links on devices for quick settings access.

* **Bug Fixes**
  * Improved API error handling with faster failure on client errors.
  * Fixed notification scheduler shutdown handling.

* **Documentation**
  * Enhanced README with detailed device and sensor descriptions.
  * Expanded language support documentation (English, Portuguese, Spanish).

* **Chores**
  * Version bumped to 0.6.0.
  * Added automated testing workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hudsonbrendon/HA-solar-plus-intelbras/pull/114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->