### PR TITLE
v0.8.0: dynamic device discovery + gold quality scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ The energy sensors feed the Energy Dashboard automatically going forward. To **b
 
 If your "plus" token rotates you'll be prompted to re-authenticate; you can also **Reconfigure** the entry to change the email/plus without removing it.
 
+# How it works
+
+The integration is **cloud polling**: it fetches data from the Solar Plus Intelbras API on a fixed interval (default 5 minutes, configurable via the integration's **Configure** dialog). Inverters and dataloggers are discovered automatically — new devices appear without a restart, and devices removed from your account are pruned.
+
+**Use cases:** monitor live production and current power, track savings and environmental impact, follow per-inverter health/status, drive automations (e.g. notify when an inverter goes offline via the `solar_plus_intelbras.send_alert` service), and visualise generation in the Energy Dashboard.
+
+**Known limitations:** Intelbras does not provide an official API, so availability and blocking are possible (see the Disclaimer). Historical statistics are imported at monthly granularity via `import_history`.
+
 # Debugging
 
 To enable debug for Solar Plus Intelbras integration, add following to your configuration.yaml:

--- a/custom_components/solar_plus_intelbras/__init__.py
+++ b/custom_components/solar_plus_intelbras/__init__.py
@@ -14,6 +14,8 @@ import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import Platform
+from homeassistant.core import callback
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.loader import async_get_loaded_integration
 
@@ -39,6 +41,7 @@ from .const import (
 )
 from .coordinator import SolarPlusIntelbrasDataUpdateCoordinator
 from .data import SolarPlusIntelbrasData
+from .device import current_device_identifiers
 from .notify import SolarPlusIntelbrasNotifier
 from .statistics import async_import_history
 
@@ -91,6 +94,18 @@ async def async_setup_entry(
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
+
+    @callback
+    def _prune_stale_devices() -> None:
+        """Remove devices for inverters/dataloggers no longer reported by the API."""
+        current = current_device_identifiers(entry.entry_id, coordinator.data)
+        registry = dr.async_get(hass)
+        for device in dr.async_entries_for_config_entry(registry, entry.entry_id):
+            if device.identifiers.isdisjoint(current):
+                registry.async_update_device(device.id, remove_config_entry_id=entry.entry_id)
+
+    _prune_stale_devices()
+    entry.async_on_unload(coordinator.async_add_listener(_prune_stale_devices))
 
     return True
 

--- a/custom_components/solar_plus_intelbras/binary_sensor.py
+++ b/custom_components/solar_plus_intelbras/binary_sensor.py
@@ -9,10 +9,12 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
+from homeassistant.core import callback
 from homeassistant.helpers.entity import EntityCategory
 
 from .device import inverter_device_info
 from .entity import SolarPlusIntelbrasEntity
+from .sensor import row_ids
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -36,8 +38,7 @@ def build_binary_entities(
     coordinator: SolarPlusIntelbrasDataUpdateCoordinator,
 ) -> list[BinarySensorEntity]:
     """One connectivity binary sensor per inverter row."""
-    rows = coordinator.data.get("inverters", {}).get("rows") or []
-    return [SolarPlusIntelbrasOnlineBinarySensor(coordinator, index) for index in range(len(rows))]
+    return [SolarPlusIntelbrasOnlineBinarySensor(coordinator, row_id) for row_id in row_ids(coordinator.data)]
 
 
 async def async_setup_entry(
@@ -45,8 +46,23 @@ async def async_setup_entry(
     entry: SolarPlusIntelbrasConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the binary_sensor platform."""
-    async_add_entities(build_binary_entities(entry.runtime_data.coordinator))
+    """Set up the binary_sensor platform with dynamic per-inverter discovery."""
+    coordinator = entry.runtime_data.coordinator
+    known: set = set()
+
+    @callback
+    def _add_new_inverters() -> None:
+        new = []
+        for row_id in row_ids(coordinator.data):
+            if row_id in known:
+                continue
+            known.add(row_id)
+            new.append(SolarPlusIntelbrasOnlineBinarySensor(coordinator, row_id))
+        if new:
+            async_add_entities(new)
+
+    _add_new_inverters()
+    entry.async_on_unload(coordinator.async_add_listener(_add_new_inverters))
 
 
 class SolarPlusIntelbrasOnlineBinarySensor(SolarPlusIntelbrasEntity, BinarySensorEntity):
@@ -57,20 +73,28 @@ class SolarPlusIntelbrasOnlineBinarySensor(SolarPlusIntelbrasEntity, BinarySenso
     def __init__(
         self,
         coordinator: SolarPlusIntelbrasDataUpdateCoordinator,
-        row_index: int,
+        row_id: object,
     ) -> None:
         """Initialize."""
         super().__init__(coordinator)
-        self._row_index = row_index
+        self._row_id = row_id
         entry_id = coordinator.config_entry.entry_id
-        row = self._row
-        self._attr_unique_id = f"{entry_id}_inverter_{row.get('id')}_online"
-        self._attr_device_info = inverter_device_info(entry_id, row)
+        self._attr_unique_id = f"{entry_id}_inverter_{row_id}_online"
+        self._attr_device_info = inverter_device_info(entry_id, self._row)
 
     @property
     def _row(self) -> dict:
         rows = self.coordinator.data.get("inverters", {}).get("rows") or []
-        return rows[self._row_index] if self._row_index < len(rows) else {}
+        for row in rows:
+            if row.get("id") == self._row_id:
+                return row
+        return {}
+
+    @property
+    def available(self) -> bool:
+        """Available only while the inverter row still exists."""
+        rows = self.coordinator.data.get("inverters", {}).get("rows") or []
+        return super().available and any(row.get("id") == self._row_id for row in rows)
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/solar_plus_intelbras/device.py
+++ b/custom_components/solar_plus_intelbras/device.py
@@ -9,6 +9,20 @@ from .const import DOMAIN
 CONFIGURATION_URL = "https://solarplus.intelbras.com.br/"
 
 
+def current_device_identifiers(entry_id: str, data: dict) -> set[tuple[str, str]]:
+    """
+    Return the device identifiers that should currently exist for an entry.
+
+    Used to prune devices (inverters/dataloggers) that disappeared from the API.
+    """
+    identifiers: set[tuple[str, str]] = {(DOMAIN, f"{entry_id}_plant")}
+    for row in data.get("inverters", {}).get("rows") or []:
+        identifiers.add((DOMAIN, f"{entry_id}_inverter_{row.get('id')}"))
+        datalogger_id = (row.get("datalogger") or {}).get("id")
+        identifiers.add((DOMAIN, f"{entry_id}_datalogger_{datalogger_id}"))
+    return identifiers
+
+
 def plant_device_info(entry_id: str, plant_name: str) -> DeviceInfo:
     """Return DeviceInfo for the plant (top-level device)."""
     return DeviceInfo(

--- a/custom_components/solar_plus_intelbras/manifest.json
+++ b/custom_components/solar_plus_intelbras/manifest.json
@@ -15,7 +15,7 @@
   "loggers": [
     "custom_components.solar_plus_intelbras"
   ],
-  "quality_scale": "silver",
+  "quality_scale": "gold",
   "requirements": [],
-  "version": "0.7.0"
+  "version": "0.8.0"
 }

--- a/custom_components/solar_plus_intelbras/quality_scale.yaml
+++ b/custom_components/solar_plus_intelbras/quality_scale.yaml
@@ -63,9 +63,7 @@ rules:
   docs-supported-functions: done
   docs-troubleshooting: done
   docs-use-cases: done
-  dynamic-devices:
-    status: todo
-    comment: Inverters/dataloggers are read at setup; new ones need a reload.
+  dynamic-devices: done
   entity-category: done
   entity-device-class: done
   entity-disabled-by-default: done
@@ -76,9 +74,7 @@ rules:
   repair-issues:
     status: exempt
     comment: No actionable repairs beyond the built-in reauthentication flow.
-  stale-devices:
-    status: todo
-    comment: Removed devices are not pruned automatically yet.
+  stale-devices: done
 
   # Platinum
   async-dependency: done

--- a/custom_components/solar_plus_intelbras/sensor.py
+++ b/custom_components/solar_plus_intelbras/sensor.py
@@ -5,12 +5,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
+from homeassistant.core import callback
 
-from .device import (
-    datalogger_device_info,
-    inverter_device_info,
-    plant_device_info,
-)
+from .device import datalogger_device_info, inverter_device_info, plant_device_info
 from .entity import SolarPlusIntelbrasEntity
 from .sensor_descriptions import (
     DATALOGGER_SENSORS,
@@ -31,24 +28,56 @@ if TYPE_CHECKING:
 PARALLEL_UPDATES = 0
 
 
-def build_entities(
-    coordinator: SolarPlusIntelbrasDataUpdateCoordinator,
-) -> list[SensorEntity]:
-    """Create one set of plant sensors plus per-inverter/datalogger sensors."""
-    plant = (coordinator.data.get("inverters", {}).get("rows") or [{}])[0].get("plant") or {}
-    entities: list[SensorEntity] = [
-        SolarPlusIntelbrasPlantSensor(coordinator, description, plant.get("name", "")) for description in PLANT_SENSORS
-    ]
+def _rows(data: dict) -> list[dict]:
+    return data.get("inverters", {}).get("rows") or []
 
-    rows = coordinator.data.get("inverters", {}).get("rows") or []
-    for index, _row in enumerate(rows):
-        entities.extend(
-            SolarPlusIntelbrasInverterSensor(coordinator, description, index) for description in INVERTER_SENSORS
-        )
-        entities.extend(
-            SolarPlusIntelbrasDataloggerSensor(coordinator, description, index) for description in DATALOGGER_SENSORS
-        )
+
+def row_ids(data: dict) -> list:
+    """Return the inverter row ids present in the coordinator data."""
+    return [row["id"] for row in _rows(data) if "id" in row]
+
+
+def build_plant_entities(coordinator: SolarPlusIntelbrasDataUpdateCoordinator) -> list[SensorEntity]:
+    """Return the (static) plant-level sensors."""
+    plant = (_rows(coordinator.data) or [{}])[0].get("plant") or {}
+    name = plant.get("name", "")
+    return [SolarPlusIntelbrasPlantSensor(coordinator, description, name) for description in PLANT_SENSORS]
+
+
+def build_row_entities(
+    coordinator: SolarPlusIntelbrasDataUpdateCoordinator,
+    row_id: object,
+) -> list[SensorEntity]:
+    """Return the inverter and datalogger sensors for a single inverter id."""
+    entities: list[SensorEntity] = [
+        SolarPlusIntelbrasInverterSensor(coordinator, description, row_id) for description in INVERTER_SENSORS
+    ]
+    entities.extend(
+        SolarPlusIntelbrasDataloggerSensor(coordinator, description, row_id) for description in DATALOGGER_SENSORS
+    )
     return entities
+
+
+def build_entities(coordinator: SolarPlusIntelbrasDataUpdateCoordinator) -> list[SensorEntity]:
+    """Return all current entities (plant + per-inverter/datalogger)."""
+    entities = build_plant_entities(coordinator)
+    for row_id in row_ids(coordinator.data):
+        entities.extend(build_row_entities(coordinator, row_id))
+    return entities
+
+
+def new_row_entities(
+    coordinator: SolarPlusIntelbrasDataUpdateCoordinator,
+    known: set,
+) -> list[SensorEntity]:
+    """Return entities for inverter ids not yet in ``known`` and record them."""
+    new: list[SensorEntity] = []
+    for row_id in row_ids(coordinator.data):
+        if row_id in known:
+            continue
+        known.add(row_id)
+        new.extend(build_row_entities(coordinator, row_id))
+    return new
 
 
 async def async_setup_entry(
@@ -56,8 +85,20 @@ async def async_setup_entry(
     entry: SolarPlusIntelbrasConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the sensor platform."""
-    async_add_entities(build_entities(entry.runtime_data.coordinator))
+    """Set up the sensor platform with dynamic per-inverter discovery."""
+    coordinator = entry.runtime_data.coordinator
+    async_add_entities(build_plant_entities(coordinator))
+
+    known: set = set()
+
+    @callback
+    def _add_new_inverters() -> None:
+        entities = new_row_entities(coordinator, known)
+        if entities:
+            async_add_entities(entities)
+
+    _add_new_inverters()
+    entry.async_on_unload(coordinator.async_add_listener(_add_new_inverters))
 
 
 class _BaseSensor(SolarPlusIntelbrasEntity, SensorEntity):
@@ -96,29 +137,30 @@ class SolarPlusIntelbrasPlantSensor(_BaseSensor):
 
 
 class _RowSensor(_BaseSensor):
-    """Base for sensors whose value_fn receives a single inverter row."""
+    """Base for sensors bound to a single inverter row (looked up by id)."""
 
     def __init__(
         self,
         coordinator: SolarPlusIntelbrasDataUpdateCoordinator,
         description: SolarPlusSensorEntityDescription,
-        row_index: int,
+        row_id: object,
     ) -> None:
         """Initialize."""
         super().__init__(coordinator)
         self.entity_description = description
-        self._row_index = row_index
+        self._row_id = row_id
 
     @property
     def _row(self) -> dict:
-        rows = self.coordinator.data.get("inverters", {}).get("rows") or []
-        return rows[self._row_index] if self._row_index < len(rows) else {}
+        for row in _rows(self.coordinator.data):
+            if row.get("id") == self._row_id:
+                return row
+        return {}
 
     @property
     def available(self) -> bool:
-        """Available only while the row still exists."""
-        rows = self.coordinator.data.get("inverters", {}).get("rows") or []
-        return super().available and self._row_index < len(rows)
+        """Available only while the inverter row still exists."""
+        return super().available and any(row.get("id") == self._row_id for row in _rows(self.coordinator.data))
 
     @property
     def native_value(self) -> StateType:
@@ -133,14 +175,13 @@ class SolarPlusIntelbrasInverterSensor(_RowSensor):
         self,
         coordinator: SolarPlusIntelbrasDataUpdateCoordinator,
         description: SolarPlusSensorEntityDescription,
-        row_index: int,
+        row_id: object,
     ) -> None:
         """Initialize."""
-        super().__init__(coordinator, description, row_index)
+        super().__init__(coordinator, description, row_id)
         entry_id = coordinator.config_entry.entry_id
-        row = self._row
-        self._attr_unique_id = f"{entry_id}_inverter_{row.get('id')}_{description.key}"
-        self._attr_device_info = inverter_device_info(entry_id, row)
+        self._attr_unique_id = f"{entry_id}_inverter_{row_id}_{description.key}"
+        self._attr_device_info = inverter_device_info(entry_id, self._row)
 
 
 class SolarPlusIntelbrasDataloggerSensor(_RowSensor):
@@ -150,12 +191,11 @@ class SolarPlusIntelbrasDataloggerSensor(_RowSensor):
         self,
         coordinator: SolarPlusIntelbrasDataUpdateCoordinator,
         description: SolarPlusSensorEntityDescription,
-        row_index: int,
+        row_id: object,
     ) -> None:
         """Initialize."""
-        super().__init__(coordinator, description, row_index)
+        super().__init__(coordinator, description, row_id)
         entry_id = coordinator.config_entry.entry_id
-        row = self._row
-        datalogger_id = (row.get("datalogger") or {}).get("id")
+        datalogger_id = (self._row.get("datalogger") or {}).get("id")
         self._attr_unique_id = f"{entry_id}_datalogger_{datalogger_id}_{description.key}"
-        self._attr_device_info = datalogger_device_info(entry_id, row)
+        self._attr_device_info = datalogger_device_info(entry_id, self._row)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from custom_components.solar_plus_intelbras.const import DOMAIN
 from custom_components.solar_plus_intelbras.device import (
+    current_device_identifiers,
     datalogger_device_info,
     inverter_device_info,
     plant_device_info,
@@ -33,3 +34,13 @@ def test_datalogger_device_is_child_of_inverter(inverters_response: dict) -> Non
     info = datalogger_device_info("entry1", row)
     assert (DOMAIN, "entry1_datalogger_1139") in info["identifiers"]
     assert info["via_device"] == (DOMAIN, "entry1_inverter_2113")
+
+
+def test_current_device_identifiers(inverters_response: dict) -> None:
+    """The current identifiers cover plant + each inverter and datalogger."""
+    ids = current_device_identifiers("entry1", {"inverters": inverters_response})
+    assert ids == {
+        (DOMAIN, "entry1_plant"),
+        (DOMAIN, "entry1_inverter_2113"),
+        (DOMAIN, "entry1_datalogger_1139"),
+    }

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import copy
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -15,6 +17,7 @@ from custom_components.solar_plus_intelbras.const import (
     CONF_PLUS,
     DOMAIN,
 )
+from custom_components.solar_plus_intelbras.coordinator import build_coordinator_data
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -71,3 +74,48 @@ async def test_import_history_service_for_loaded_entry(hass: HomeAssistant) -> N
         await hass.async_block_till_done()
         await hass.services.async_call(DOMAIN, "import_history", {"years": 1}, blocking=True)
     imp.assert_awaited_once()
+
+
+def _entry_ids(hass: HomeAssistant, entry_id: str) -> set[tuple[str, str]]:
+    registry = dr.async_get(hass)
+    ids: set[tuple[str, str]] = set()
+    for device in dr.async_entries_for_config_entry(registry, entry_id):
+        ids |= device.identifiers
+    return ids
+
+
+async def test_dynamic_and_stale_devices(hass: HomeAssistant, inverters_response: dict) -> None:
+    """New inverters are added at runtime and removed ones are pruned."""
+    row1 = inverters_response["rows"][0]
+    row2 = copy.deepcopy(row1)
+    row2["id"] = 9999
+    row2["datalogger"] = copy.deepcopy(row1["datalogger"])
+    row2["datalogger"]["id"] = 8888
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="42",
+        data={CONF_EMAIL: "e@mail.com", CONF_PLUS: "p", CONF_PLANT_ID: "42"},
+    )
+    entry.add_to_hass(hass)
+
+    with patch(_GET_DATA, new=AsyncMock(return_value={"rows": [row1]})):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    eid = entry.entry_id
+    assert (DOMAIN, f"{eid}_inverter_2113") in _entry_ids(hass, eid)
+
+    coordinator = entry.runtime_data.coordinator
+
+    # A second inverter appears -> its device is added dynamically.
+    coordinator.async_set_updated_data(build_coordinator_data({"rows": [row1, row2]}, None, "BRL"))
+    await hass.async_block_till_done()
+    assert (DOMAIN, f"{eid}_inverter_9999") in _entry_ids(hass, eid)
+
+    # The first inverter disappears -> its device is pruned.
+    coordinator.async_set_updated_data(build_coordinator_data({"rows": [row2]}, None, "BRL"))
+    await hass.async_block_till_done()
+    ids = _entry_ids(hass, eid)
+    assert (DOMAIN, f"{eid}_inverter_2113") not in ids
+    assert (DOMAIN, f"{eid}_inverter_9999") in ids

--- a/tests/test_sensor_setup.py
+++ b/tests/test_sensor_setup.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import copy
+
 from custom_components.solar_plus_intelbras.sensor import (
     SolarPlusIntelbrasInverterSensor,
     build_entities,
+    new_row_entities,
 )
 from custom_components.solar_plus_intelbras.sensor_descriptions import (
     DATALOGGER_SENSORS,
@@ -29,12 +32,32 @@ def test_build_entities_counts(coordinator_data: dict) -> None:
 
 
 def test_row_sensor_unavailable_when_row_disappears(coordinator_data: dict) -> None:
-    """A per-row sensor becomes unavailable (value None) if its row is gone."""
+    """A per-row sensor becomes unavailable (value None) if its inverter is gone."""
     coordinator = _FakeCoordinator(coordinator_data)
-    sensor = SolarPlusIntelbrasInverterSensor(coordinator, INVERTER_SENSORS[0], 0)
+    sensor = SolarPlusIntelbrasInverterSensor(coordinator, INVERTER_SENSORS[0], 2113)
     coordinator.data = {"inverters": {"rows": []}, "year_energy": None, "currency": "BRL"}
     assert sensor.available is False
     assert sensor.native_value is None
+
+
+def test_new_row_entities_only_returns_unseen_inverters(coordinator_data: dict) -> None:
+    """Dynamic discovery adds entities only for inverter ids not yet seen."""
+    coordinator = _FakeCoordinator(coordinator_data)
+    known: set = set()
+    first = new_row_entities(coordinator, known)
+    assert len(first) == len(INVERTER_SENSORS) + len(DATALOGGER_SENSORS)
+    # Same data again -> nothing new.
+    assert new_row_entities(coordinator, known) == []
+    # A second inverter appears -> only its entities are created.
+    data = copy.deepcopy(coordinator_data)
+    second_row = copy.deepcopy(data["inverters"]["rows"][0])
+    second_row["id"] = 9999
+    second_row["datalogger"]["id"] = 8888
+    data["inverters"]["rows"].append(second_row)
+    coordinator.data = data
+    added = new_row_entities(coordinator, known)
+    assert len(added) == len(INVERTER_SENSORS) + len(DATALOGGER_SENSORS)
+    assert all("_9999_" in e.unique_id or "_8888_" in e.unique_id for e in added)
 
 
 def test_unique_ids_are_distinct(coordinator_data: dict) -> None:


### PR DESCRIPTION
Reaches the **gold** quality scale by implementing the last two gold rules.

## Dynamic devices (`dynamic-devices`)
- Per-inverter and per-datalogger entities are now keyed by **inverter id** instead of list index, so they remain stable when rows are added/removed/reordered.
- New inverters are discovered at runtime via a coordinator listener — they appear without restarting Home Assistant.

## Stale devices (`stale-devices`)
- Inverters/dataloggers removed from the account are pruned from the device registry on the next update.

## Quality scale → gold
- `quality_scale: gold` in the manifest; `quality_scale.yaml` updated (validated locally with hassfest). Remaining items are platinum-tier (`strict-typing`).

## Tests
- Unit tests for id-based lookups, `new_row_entities`, `current_device_identifiers`, and per-row availability; an **integration test** that sets up an entry, adds a second inverter at runtime (asserts the device appears) and removes the first (asserts it is pruned).
- Coverage ~97% (95% gate enforced in CI).

## Docs
- README: "How it works" (cloud polling, auto-discovery), use cases, known limitations.

## Test Plan
- [x] `pytest` (95% gate) → all pass, ~97%
- [x] `ruff check .` + `ruff format . --check` → clean
- [x] `hassfest` (local Docker) → 0 invalid, quality_scale: gold
- [ ] Manual: add a second inverter to the account and confirm it appears; remove one and confirm its device is pruned